### PR TITLE
fix(ci): bump macOS mediainfo pin 26.01 -> 26.05

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,8 @@ All contributors (including maintainers) should update `CHANGELOG.md` when creat
 
 - **python-project-standards v4.3.2** ([org **`v4.3.2`**](https://github.com/BehindTheMusicTree/python-project-standards/releases/tag/v4.3.2)): Lint delegates to **`reusable-pre-commit.yml@v4.3.2`**; root **`STANDARDS_VERSION`** **`4.3.2`**. [**`scripts/check_lint_baseline.py`**](scripts/check_lint_baseline.py) requires **`baselines/ruff.toml`** and **`baselines/expected-mypy.json`** in **`baselines/DIGESTS`**. [**`scripts/verify-standards.sh`**](scripts/verify-standards.sh) matches org on this bump.
 
+- **macOS `mediainfo` pin**: Bumped `mediainfo` from `26.01` to `26.05` in [**`system-dependencies-test-only.toml`**](system-dependencies-test-only.toml) to match the version Homebrew's `media-info` formula currently provides (Homebrew doesn't retain older bottles for this formula).
+
 ## [1.4.3] - 2026-04-11
 
 ### Fixed

--- a/system-dependencies-test-only.toml
+++ b/system-dependencies-test-only.toml
@@ -34,7 +34,7 @@ libsndfile1 = "latest"  # TEST dependency - required by soundfile (used only in 
 # Note: mediainfo (media-info in Homebrew) cannot be pinned - Homebrew installs whatever version
 # is currently in the formula. If CI fails with version mismatch, update this pinned version to
 # match what Homebrew currently provides (check with: brew info media-info).
-mediainfo = "26.01"
+mediainfo = "26.05"
 exiftool = { source = "exiftool_org", pinned_version = "13.55" }
 bwfmetaedit = "26.01"  # Used in test helpers for RIFF metadata setup
 libsndfile = "1.2.2"  # TEST dependency - required by soundfile (used only in tests)


### PR DESCRIPTION
## Description

Homebrew's `media-info` formula moved past the pinned version (`26.01`) with no older bottle available, causing the macOS test job's exact-version check to fail. Bumps the pin to `26.05` to match what Homebrew currently provides.

Split out of #80 as a standalone, independently-mergeable fix (unrelated to that PR's content changes).

## Type of Change

- [x] CI/CD or infrastructure change