### PR TITLE
fix: allow DISC_NUMBER to be optional, matching DISC_TOTAL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,12 @@ All contributors (including maintainers) should update `CHANGELOG.md` when creat
 
 ## [Unreleased]
 
+### Fixed
+
+- **Metadata schema**: `DISC_NUMBER`'s optional type now allows `None` (was `int`), matching `DISC_TOTAL` and files without a disc number.
+- **Field schema regression**: [**`unified_metadata_field_schema.py`**](audiometa/utils/unified_metadata_field_schema.py) special-cased `DISC_TOTAL` to report `value_type: "integer"` / `optional_value: True`, but relied on `get_optional_type() is int` for `DISC_NUMBER`; since `DISC_NUMBER`'s optional type is now `int | None`, that check silently fell through to `"string"` / `optional_value: False`. `DISC_NUMBER` now shares `DISC_TOTAL`'s explicit branch.
+- **Type annotation**: [**`UnifiedMetadataKey.get_optional_type()`**](audiometa/utils/unified_metadata_key.py) was annotated as returning `type[int | float | str | list[str]]`, but its map already returned non-`type` runtime objects (e.g. `int | float`, and now `int | None`). Corrected the return annotation to `object` and narrowed with `cast()` at the one call site that requires a plain `type` for `isinstance()`.
+
 ### Changed
 
 - **Release tooling**: Replaced unmaintained **`bump2version`** with **`bump-my-version`**; configuration lives in **`pyproject.toml`** under **`[tool.bumpversion]`**. Removed **`.bumpversion.cfg`**. **`scripts/prepare_release.py`** invokes **`bump-my-version bump`** (no commit/tag; the script commits and tags separately).

--- a/audiometa/__init__.py
+++ b/audiometa/__init__.py
@@ -451,7 +451,7 @@ def _validate_unified_metadata_types(unified_metadata: UnifiedMetadata) -> None:
                 type_names = ", ".join(getattr(t, "__name__", str(t)) if t is not None else "None" for t in arg_types)
                 raise InvalidMetadataFieldTypeError(key.value, f"Union[{type_names}]", value)
         # expected_type is a plain type like str or int
-        elif not isinstance(value, expected_type):
+        elif not isinstance(value, cast(type, expected_type)):
             # Special case for TRACK_NUMBER: allow int for writing convenience (returns string when reading)
             if key == UnifiedMetadataKey.TRACK_NUMBER and isinstance(value, int | str):
                 continue

--- a/audiometa/test/tests/unit/utils/test_unified_metadata_field_schema.py
+++ b/audiometa/test/tests/unit/utils/test_unified_metadata_field_schema.py
@@ -11,7 +11,7 @@ def _expected_value_shape(key: UnifiedMetadataKey) -> tuple[str, bool, bool]:
         return ("strings", True, False)
     if key == UnifiedMetadataKey.TRACK_NUMBER:
         return ("string_or_integer", False, False)
-    if key == UnifiedMetadataKey.DISC_TOTAL:
+    if key in (UnifiedMetadataKey.DISC_NUMBER, UnifiedMetadataKey.DISC_TOTAL):
         return ("integer", False, True)
     if key == UnifiedMetadataKey.RATING:
         return ("number", False, False)
@@ -69,6 +69,12 @@ class TestUnifiedMetadataFieldSchema:
         assert d["value_type"] == "string_or_integer"
         assert d["multiple"] is False
         assert d["optional_value"] is False
+
+    def test_describe_disc_number_integer_optional_value(self) -> None:
+        d = describe_unified_metadata_field(UnifiedMetadataKey.DISC_NUMBER)
+        assert d["value_type"] == "integer"
+        assert d["optional_value"] is True
+        assert d["multiple"] is False
 
     def test_describe_disc_total_integer_optional_value(self) -> None:
         d = describe_unified_metadata_field(UnifiedMetadataKey.DISC_TOTAL)

--- a/audiometa/utils/unified_metadata_field_schema.py
+++ b/audiometa/utils/unified_metadata_field_schema.py
@@ -49,7 +49,7 @@ for _k in UnifiedMetadataKey:
         _VALUE_SHAPE[_k] = ("strings", True, False)
     elif _k == UnifiedMetadataKey.TRACK_NUMBER:
         _VALUE_SHAPE[_k] = ("string_or_integer", False, False)
-    elif _k == UnifiedMetadataKey.DISC_TOTAL:
+    elif _k in (UnifiedMetadataKey.DISC_NUMBER, UnifiedMetadataKey.DISC_TOTAL):
         _VALUE_SHAPE[_k] = ("integer", False, True)
     elif _k == UnifiedMetadataKey.RATING:
         _VALUE_SHAPE[_k] = ("number", False, False)

--- a/audiometa/utils/unified_metadata_key.py
+++ b/audiometa/utils/unified_metadata_key.py
@@ -5,7 +5,6 @@ format.
 """
 
 from enum import StrEnum
-from typing import cast
 
 
 class UnifiedMetadataKey(StrEnum):
@@ -60,11 +59,12 @@ class UnifiedMetadataKey(StrEnum):
             raise ValueError(msg)
         return result
 
-    def get_optional_type(self) -> type[int | float | str | list[str]]:
+    def get_optional_type(self) -> object:
         """Get the optional type for the metadata key.
 
         Returns:
-            The type of the metadata value.
+            The expected type of the metadata value. This may be a concrete type (e.g. ``str``), a union
+            (e.g. ``int | None``), or a generic alias (e.g. ``list[str]``) rather than always a ``type`` instance.
         """
         app_metadata_keys_optional_types_map: dict[UnifiedMetadataKey, object] = {
             UnifiedMetadataKey.TITLE: str,
@@ -76,7 +76,7 @@ class UnifiedMetadataKey(StrEnum):
             UnifiedMetadataKey.LANGUAGE: str,
             UnifiedMetadataKey.RELEASE_DATE: str,
             UnifiedMetadataKey.TRACK_NUMBER: str,  # Can be int or str
-            UnifiedMetadataKey.DISC_NUMBER: int,
+            UnifiedMetadataKey.DISC_NUMBER: int | None,
             UnifiedMetadataKey.DISC_TOTAL: int | None,
             UnifiedMetadataKey.BPM: int,
             UnifiedMetadataKey.COMPOSERS: list[str],
@@ -96,4 +96,4 @@ class UnifiedMetadataKey(StrEnum):
         if not result_type:
             msg = f"No optional type defined for {self}"
             raise ValueError(msg)
-        return cast(type[int | float | str | list[str]], result_type)
+        return result_type


### PR DESCRIPTION
## Description

`DISC_NUMBER`'s optional type was `int`-only, so files without a disc number failed unified-metadata schema validation, while `DISC_TOTAL` (also optional) validated fine.

Fixing that type surfaced two more bugs:
- `unified_metadata_field_schema.py` special-cased `DISC_TOTAL` to report `value_type: "integer"` / `optional_value: True`, but relied on `get_optional_type() is int` for `DISC_NUMBER` — once `DISC_NUMBER`'s optional type became `int | None`, that check silently fell through to `"string"` / `optional_value: False`. `DISC_NUMBER` now shares `DISC_TOTAL`'s explicit branch.
- `UnifiedMetadataKey.get_optional_type()` was annotated as returning `type[int | float | str | list[str]]`, but its map already returned non-`type` runtime objects (e.g. `int | float`, and now `int | None`). Corrected the return annotation to `object` and narrowed with `cast()` at the one call site that requires a plain `type` for `isinstance()`.

Split out of #80 as a standalone, independently-mergeable library bug fix (unrelated to that PR's content changes).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Tests

- `pytest audiometa/test/tests/unit/utils/test_unified_metadata_field_schema.py` — 10 passed